### PR TITLE
Basic proof-of-concept for two monitors

### DIFF
--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -41,8 +41,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int 
 {
 
 	HWND taskbar = FindWindowA("Shell_TrayWnd", NULL);
+	HWND secondtaskbar = FindWindowA("Shell_SecondaryTrayWnd", NULL);
+	
 	while (true) {
-		SetWindowBlur(taskbar); Sleep((DWORD)10);
+		SetWindowBlur(taskbar); 
+		SetWindowBlur(secondtaskbar);
+		Sleep((DWORD)10);
 	}
 	FreeLibrary(hModule);
 


### PR DESCRIPTION
Added HWND for "secondtaskbar", which references the second taskbar's class. These changes have no side effects if Shell_SecondaryTrayWnd is not found.

I don't know the name for the third monitor. Could anybody help?