### PR TITLE
Updated to allow for iteration over multiple windows with class Shell_SecondaryTrayWnd (secondary taskbars)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,5 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+
+transparent.xml

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ A lightweight utility that makes the Windows taskbar translucent/transparent.
 
 #Download
 You can download the program [via the releases tab](https://github.com/ethanhs/TranslucentTB/releases).
+
+#Compile
+Want to compile yourself? My releases were compiled using the Microsoft Visual Studio build tools. You'll need Visual Studio first.
+
+Open "Visual C++ 2015 x86 Native Build Tools Command Prompt" from the Start menu. Once you've `cd`'d into the code's directory, `cd` into the TranslucentTB folder and run `cl main.cpp /Fe"TranslucentTb" /link /subsystem:windows user32.lib` to create `TranslucentTb.exe`.

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,4 +1,8 @@
 #include <windows.h>
+#include <fstream>
+#include <iostream>
+
+using namespace std;
 
 const HINSTANCE hModule = LoadLibrary(TEXT("user32.dll"));
 
@@ -28,7 +32,12 @@ void SetWindowBlur(HWND hWnd)
 	{	
 		if (SetWindowCompositionAttribute)
 		{
-			ACCENTPOLICY policy = { 3, 0, 0, 0 }; // ACCENT_ENABLE_BLURBEHIND=3, ACCENT_INVALID=4...
+			ACCENTPOLICY policy;
+			ifstream file("transparent.xml");
+			if(!file)
+				policy = { 3, 0, 0, 0 }; // ACCENT_ENABLE_BLURBEHIND=3, ACCENT_INVALID=4...
+			else
+				policy = {2, 2, 0, 0};
 			WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) }; // WCA_ACCENT_POLICY=19
 			SetWindowCompositionAttribute(hWnd, &data);
 		}

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -40,12 +40,14 @@ void SetWindowBlur(HWND hWnd)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int nCmdShow)
 {
 
-	HWND taskbar = FindWindowA("Shell_TrayWnd", NULL);
-	HWND secondtaskbar = FindWindowA("Shell_SecondaryTrayWnd", NULL);
+	HWND mainTb, otherTb ;
+	mainTb = FindWindowA("Shell_TrayWnd", NULL); // Primary desktop taskbar
+		// = FindWindowA("Shell_SecondaryTrayWnd", NULL);
 	
 	while (true) {
-		SetWindowBlur(taskbar); 
-		SetWindowBlur(secondtaskbar);
+		SetWindowBlur(mainTb); 
+		while (otherTb = FindWindowEx(0, otherTb, "Shell_SecondaryTrayWnd", ""))
+    		SetWindowBlur(otherTb);
 		Sleep((DWORD)10);
 	}
 	FreeLibrary(hModule);


### PR DESCRIPTION
Used the [knowledge gained by @ethanhs and @PFCKrutonium](https://github.com/ethanhs/TranslucentTB/pull/1), who state that second monitors and beyond all use the same class name: Shell_SecondaryTrayWnd (the primary desktop has Shell_TrayWnd).

FindWindowEx is used with a loop to iterate over *all* HWNDs with class Shell_SecondaryTrayWnd and runs SetWindowBlur on each.