### PR TITLE
Explicit unicode support and command-line arguments.

### DIFF
--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,6 +1,6 @@
 #include <windows.h>
 
-const HINSTANCE hModule = LoadLibrary(TEXT("user32.dll"));
+const HINSTANCE hModule = LoadLibrary(L"user32.dll");
 
 struct ACCENTPOLICY
 {
@@ -23,16 +23,15 @@ const pSetWindowCompositionAttribute SetWindowCompositionAttribute = (pSetWindow
 
 void SetWindowBlur(HWND hWnd)
 {
-	
 	if (hModule)
-	{	
+	{
 		if (SetWindowCompositionAttribute)
 		{
 			ACCENTPOLICY policy = { 3, 0, 0, 0 }; // ACCENT_ENABLE_BLURBEHIND=3, ACCENT_INVALID=4...
 			WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) }; // WCA_ACCENT_POLICY=19
 			SetWindowCompositionAttribute(hWnd, &data);
 		}
-		
+
 	}
 }
 
@@ -40,8 +39,9 @@ void SetWindowBlur(HWND hWnd)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int nCmdShow)
 {
 
-	HWND taskbar = FindWindowA("Shell_TrayWnd", NULL);
-	while (true) {
+	HWND taskbar = FindWindowW(L"Shell_TrayWnd", NULL);
+	while (true)
+	{
 		SetWindowBlur(taskbar); Sleep((DWORD)10);
 	}
 	FreeLibrary(hModule);

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,4 +1,5 @@
 #include <windows.h>
+//#include <iostream>
 
 const HINSTANCE hModule = LoadLibrary(L"user32.dll");
 
@@ -16,6 +17,15 @@ struct WINCOMPATTRDATA
 	ULONG ulDataSize;
 };
 
+struct OPTIONS
+{
+	int mode;
+	int color;
+} opt;
+
+const int ACCENT_ENABLE_GRADIENT = 1;
+const int ACCENT_ENABLE_TRANSPARENTGRADIENT = 2;
+const int ACCENT_ENABLE_BLURBEHIND = 3;
 
 
 typedef BOOL(WINAPI*pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
@@ -27,7 +37,44 @@ void SetWindowBlur(HWND hWnd)
 	{
 		if (SetWindowCompositionAttribute)
 		{
-			ACCENTPOLICY policy = { 3, 0, 0, 0 }; // ACCENT_ENABLE_BLURBEHIND=3, ACCENT_INVALID=4...
+			ACCENTPOLICY policy;
+
+			if (opt.mode == ACCENT_ENABLE_GRADIENT)
+			{
+				// Makes the taskbar a solid color specified by nColor.
+				// This mode doesn't care about the alpha channel.
+				// nFlags doesn't seem to matter.
+				// nAccentState = ACCENT_ENABLE_GRADIENT = 1
+
+				policy = { 1, 0, opt.color, 0 };
+			}
+			else if (opt.mode == ACCENT_ENABLE_TRANSPARENTGRADIENT)
+			{
+				// Makes the taskbar a tinted transparent overlay.
+				// nColor is the tint color. A value of zero makes it opaque
+				// and uses the system selected color scheme. Anything else
+				// applies a tint to the taskbar, and the alpha channel
+				// determines the opacity.
+				// nFlags doesn't seem to matter.
+				// nAccentState = ACCENT_ENABLE_TRANSPARENTGRADIENT = 2
+
+				// This has been really inconsistent on my system, sometimes the 
+				// taskbar just turns to a solid white, but launching the program
+				// a few more times with different colors in between will eventually
+				// apply the color tint as expected.
+
+				policy = { 2, 0, opt.color, 0 };
+			}
+			else if (opt.mode == ACCENT_ENABLE_BLURBEHIND)
+			{
+				// This mode only blurs the taskbar, the nColor
+				// field has no effect.
+				// nFlags doesn't matter
+				// nAccentState = ACCENT_ENABLE_BLURBEHIND = 3
+
+				policy = { 3, 0, opt.color, 0 };
+			}
+
 			WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) }; // WCA_ACCENT_POLICY=19
 			SetWindowCompositionAttribute(hWnd, &data);
 		}
@@ -36,8 +83,100 @@ void SetWindowBlur(HWND hWnd)
 }
 
 
+void PrintHelp()
+{
+	/*
+	The following won't print anything unless we explicitly call AllocConsole() and reopen stdout to
+	point to the console, or change the project settings to target the console subsystem instead
+	of the windows subsystem. Both have to problem of displaying an unwanted console in an
+	otherwise silent program. I'm not sure what the best solution would be - the simplest might be
+	to just write a small usage.txt file to accompany the program.
+	*/
+
+	/*
+	using namespace std;
+	wcout << "TranslucentTB by /u/IronManMark20" << endl;
+	wcout << "This program modifies the apperance of the windows taskbar" << endl;
+	wcout << "You can modify its behaviour by using the following parameters when launching the program:" << endl;
+	wcout << "  --blur        | will make the taskbar a blurry overlay of the background (default)." << endl;
+	wcout << "  --opaque      | will make the taskbar a solid color specified by the tint parameter." << endl;
+	wcout << "  --transparent | will make the taskbar a transparent color specified by the tint parameter. " << endl;
+	wcout << "                  the value of the alpha channel determines the opacity of the taskbar." << endl;
+	wcout << "  --tint COLOR  | specifies the color applied to the taskbar. COLOR is a hexadecimal 32 bit number." << endl;
+	wcout << "                  Will not affect the blur mode. By choosing a COLOR of zero in combination with --transparent" << endl;
+	wcout << "                  the taskbar becomes opaque and uses the selected system color scheme." << endl;
+	wcout << "  --help        | Displays this help message." << endl;
+	*/
+}
+
+void ParseOptions()
+{
+	// Set default value
+	opt.mode = ACCENT_ENABLE_BLURBEHIND;
+
+	// Loop through command line arguments
+	LPWSTR *szArglist;
+	int nArgs;
+
+	szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
+
+	for (int i = 0; i < nArgs; i++)
+	{
+		LPWSTR arg = szArglist[i];
+
+		if (wcscmp(arg, L"--help") == 0)
+		{
+			PrintHelp();
+		}
+		else if (wcscmp(arg, L"--blur") == 0)
+		{
+			opt.mode = ACCENT_ENABLE_BLURBEHIND;
+		}
+		else if (wcscmp(arg, L"--opaque") == 0)
+		{
+			opt.mode = ACCENT_ENABLE_GRADIENT;
+		}
+		else if (wcscmp(arg, L"--transparent") == 0)
+		{
+			opt.mode = ACCENT_ENABLE_TRANSPARENTGRADIENT;
+		}
+		else if (wcscmp(arg, L"--tint") == 0)
+		{
+			// The next argument should be a color in hex format
+			if (i + 1 < nArgs && wcslen(szArglist[i + 1]) > 0)
+			{
+				LPWSTR param = szArglist[i + 1];
+				unsigned long colval = 0;
+				WCHAR* stopchar;
+
+
+				colval = wcstoul(param, &stopchar, 16);
+
+
+				// ACCENTPOLICY.nColor expects the byte order to be ABGR,
+				// fiddle some bits to make it intuitive for the user.
+				opt.color =
+					(colval & 0xFF000000) +
+					((colval & 0x00FF0000) >> 16) +
+					(colval & 0x0000FF00) +
+					((colval & 0x000000FF) << 16);
+			}
+			else
+			{
+				// TODO error handling for missing value
+				// Really not much to do as we don't have functional
+				// output streams, and opening a window seems overkill.
+			}
+		}
+	}
+
+	LocalFree(szArglist);
+}
+
+
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int nCmdShow)
 {
+	ParseOptions();
 
 	HWND taskbar = FindWindowW(L"Shell_TrayWnd", NULL);
 	while (true)

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
-//#include <iostream>
+#include <iostream>
+#include <string>
 
 const HINSTANCE hModule = LoadLibraryW(L"user32.dll");
 
@@ -89,28 +90,91 @@ void SetWindowBlur(HWND hWnd)
 
 void PrintHelp()
 {
-	/*
-	The following won't print anything unless we explicitly call AllocConsole() and reopen stdout to
-	point to the console, or change the project settings to target the console subsystem instead
-	of the windows subsystem. Both have to problem of displaying an unwanted console in an
-	otherwise silent program. I'm not sure what the best solution would be - the simplest might be
-	to just write a small usage.txt file to accompany the program.
-	*/
+	// BUG - 
+	// For some reason, when launching this program in cmd.exe, it won't properly "notice"
+	// when the program has exited, and will not automatically write a new prompt to the console.
+	// Instead of printing the current directory as usual before it waits for a new command,
+	// it doesn't print anything, leading to a cluttered console.
+	// It's even worse in Powershell, where it actually WILL print the PS prompt before waiting for 
+	// a new command, but it does so on the line after "./TranslucentTB.exe --help", overwriting the 
+	// first line of output from this function, and gradually overwriting the following lines as you
+	// press enter. The PS shell just doesn't notice that anything gets printed to the console, and
+	// therefore it prints the PS prompt over this output instead of after. I don't know of any 
+	// solution to this, but I expect that setting the project type to SUBSYSTEM:CONSOLE would solve
+	// those issues. Again - I think a help file would be the best solution, so I'll do that in my 
+	// next commit.
 
-	/*
-	using namespace std;
-	wcout << "TranslucentTB by /u/IronManMark20" << endl;
-	wcout << "This program modifies the apperance of the windows taskbar" << endl;
-	wcout << "You can modify its behaviour by using the following parameters when launching the program:" << endl;
-	wcout << "  --blur        | will make the taskbar a blurry overlay of the background (default)." << endl;
-	wcout << "  --opaque      | will make the taskbar a solid color specified by the tint parameter." << endl;
-	wcout << "  --transparent | will make the taskbar a transparent color specified by the tint parameter. " << endl;
-	wcout << "                  the value of the alpha channel determines the opacity of the taskbar." << endl;
-	wcout << "  --tint COLOR  | specifies the color applied to the taskbar. COLOR is a hexadecimal 32 bit number." << endl;
-	wcout << "                  Will not affect the blur mode. By choosing a COLOR of zero in combination with --transparent" << endl;
-	wcout << "                  the taskbar becomes opaque and uses the selected system color scheme." << endl;
-	wcout << "  --help        | Displays this help message." << endl;
-	*/
+	BOOL hasconsole = true;
+	BOOL createdconsole = false;
+	// Try to attach to the parent console,
+	// allocate a new one if that isn't successful
+	if (!AttachConsole(ATTACH_PARENT_PROCESS))
+	{
+		if (!AllocConsole())
+		{
+			hasconsole = false;
+		}
+		else
+		{
+			createdconsole = true;
+		}
+	}
+
+	if (hasconsole)
+	{
+		FILE* outstream;
+		FILE* instream;
+		freopen_s(&outstream, "CONOUT$", "w", stdout);
+		freopen_s(&instream, "CONIN$", "w", stdin);
+
+		if (outstream)
+		{
+			using namespace std;
+			cout << endl;
+			cout << "TranslucentTB by /u/IronManMark20" << endl;
+			cout << "This program modifies the apperance of the windows taskbar" << endl;
+			cout << "You can modify its behaviour by using the following parameters when launching the program:" << endl;
+			cout << "  --blur        | will make the taskbar a blurry overlay of the background (default)." << endl;
+			cout << "  --opaque      | will make the taskbar a solid color specified by the tint parameter." << endl;
+			cout << "  --transparent | will make the taskbar a transparent color specified by the tint parameter. " << endl;
+			cout << "                  the value of the alpha channel determines the opacity of the taskbar." << endl;
+			cout << "  --tint COLOR  | specifies the color applied to the taskbar. COLOR is 32 bit number in hex format," << endl;
+			cout << "                  see explanation below. This will not affect the blur mode. If COLOR is zero in" << endl;
+			cout << "                  combination with --transparent the taskbar becomes opaque and uses the selected" << endl;
+			cout << "                  system color scheme." << endl;
+			cout << "  --help        | Displays this help message." << endl;
+			cout << endl;
+
+			cout << "Color format:" << endl;
+			cout << "  The parameter is interpreted as a three or four byte long number in hexadecimal format that" << endl;
+			cout << "  describes the four color channels ([alpha,] red, green and blue). These look like this:" << endl;
+			cout << "  0x80fe10a4 (the '0x' is optional). You often find colors in this format in the context of HTML and" << endl;
+			cout << "  web design, and there are many online tools to convert from familiar names to this format. These" << endl;
+			cout << "  tools might give you numbers starting with '#', in that case you can just remove the leading '#'." << endl;
+			cout << "  You should be able to find online tools by searching for \"color to hex\" or something similar." << endl;
+			cout << "  If the converter doesn't include alpha values (opacity), you can append them yourself at the start" << endl;
+			cout << "  of the number. Just convert a value between 0 and 255 to its hexadecimal value before you append it." << endl;
+			cout << endl;
+
+			if (createdconsole && instream)
+			{	
+				string wait;
+				
+				cout << "Press enter to exit the program." << endl;
+				if (!getline(cin, wait))
+				{
+					// Couldn't wait for user input, make the user close
+					// the program themselves so they can see the output.
+					cout << "Press Ctrl + C, Alt + F4, or click the close button to exit the program." << endl;
+					Sleep(INFINITE);
+				}
+
+				FreeConsole();
+			}
+
+			fclose(outstream);
+		}
+	}
 }
 
 void ParseOptions()
@@ -131,6 +195,7 @@ void ParseOptions()
 		if (wcscmp(arg, L"--help") == 0)
 		{
 			PrintHelp();
+			exit(0);
 		}
 		else if (wcscmp(arg, L"--blur") == 0)
 		{

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,7 +1,7 @@
 #include <windows.h>
 //#include <iostream>
 
-const HINSTANCE hModule = LoadLibrary(L"user32.dll");
+const HINSTANCE hModule = LoadLibraryW(L"user32.dll");
 
 struct ACCENTPOLICY
 {

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -19,9 +19,13 @@ struct WINCOMPATTRDATA
 
 struct OPTIONS
 {
-	int mode;
+	int taskbar_appearance;
 	int color;
 } opt;
+
+const int APPEARANCE_BLURRY = 1;
+const int APPEARANCE_OPAQUE = 2;
+const int APPEARANCE_TRANSPARENT = 3;
 
 const int ACCENT_ENABLE_GRADIENT = 1;
 const int ACCENT_ENABLE_TRANSPARENTGRADIENT = 2;
@@ -39,16 +43,16 @@ void SetWindowBlur(HWND hWnd)
 		{
 			ACCENTPOLICY policy;
 
-			if (opt.mode == ACCENT_ENABLE_GRADIENT)
+			if (opt.taskbar_appearance == APPEARANCE_OPAQUE)
 			{
 				// Makes the taskbar a solid color specified by nColor.
 				// This mode doesn't care about the alpha channel.
 				// nFlags doesn't seem to matter.
 				// nAccentState = ACCENT_ENABLE_GRADIENT = 1
 
-				policy = { 1, 0, opt.color, 0 };
+				policy = { ACCENT_ENABLE_GRADIENT, 0, opt.color, 0 };
 			}
-			else if (opt.mode == ACCENT_ENABLE_TRANSPARENTGRADIENT)
+			else if (opt.taskbar_appearance == APPEARANCE_TRANSPARENT)
 			{
 				// Makes the taskbar a tinted transparent overlay.
 				// nColor is the tint color. A value of zero makes it opaque
@@ -63,16 +67,16 @@ void SetWindowBlur(HWND hWnd)
 				// a few more times with different colors in between will eventually
 				// apply the color tint as expected.
 
-				policy = { 2, 0, opt.color, 0 };
+				policy = { ACCENT_ENABLE_TRANSPARENTGRADIENT, 0, opt.color, 0 };
 			}
-			else if (opt.mode == ACCENT_ENABLE_BLURBEHIND)
+			else if (opt.taskbar_appearance == APPEARANCE_BLURRY)
 			{
 				// This mode only blurs the taskbar, the nColor
 				// field has no effect.
 				// nFlags doesn't matter
 				// nAccentState = ACCENT_ENABLE_BLURBEHIND = 3
 
-				policy = { 3, 0, opt.color, 0 };
+				policy = { ACCENT_ENABLE_BLURBEHIND, 0, opt.color, 0 };
 			}
 
 			WINCOMPATTRDATA data = { 19, &policy, sizeof(ACCENTPOLICY) }; // WCA_ACCENT_POLICY=19
@@ -112,7 +116,7 @@ void PrintHelp()
 void ParseOptions()
 {
 	// Set default value
-	opt.mode = ACCENT_ENABLE_BLURBEHIND;
+	opt.taskbar_appearance = APPEARANCE_BLURRY;
 
 	// Loop through command line arguments
 	LPWSTR *szArglist;
@@ -130,15 +134,15 @@ void ParseOptions()
 		}
 		else if (wcscmp(arg, L"--blur") == 0)
 		{
-			opt.mode = ACCENT_ENABLE_BLURBEHIND;
+			opt.taskbar_appearance = APPEARANCE_BLURRY;
 		}
 		else if (wcscmp(arg, L"--opaque") == 0)
 		{
-			opt.mode = ACCENT_ENABLE_GRADIENT;
+			opt.taskbar_appearance = APPEARANCE_OPAQUE;
 		}
 		else if (wcscmp(arg, L"--transparent") == 0)
 		{
-			opt.mode = ACCENT_ENABLE_TRANSPARENTGRADIENT;
+			opt.taskbar_appearance = APPEARANCE_TRANSPARENT;
 		}
 		else if (wcscmp(arg, L"--tint") == 0)
 		{

--- a/usage.md
+++ b/usage.md
@@ -1,0 +1,21 @@
+## Usage
+This program modifies the apperance of the windows taskbar.
+You can modify its behaviour by using the following parameters when launching the program:
+
+Option | Explanation
+------------ | -------
+--blur        | will make the taskbar a blurry overlay of the background (default). 
+--opaque      | will make the taskbar a solid color specified by the tint parameter. 
+--transparent | will make the taskbar a transparent color specified by the tint parameter.  The value of the alpha channel determines the opacity of the taskbar. 
+--tint COLOR  | specifies the color applied to the taskbar. COLOR is 32 bit number in hex format, see explanation below. This will not affect the blur mode. If COLOR is zero in combination with --transparent the taskbar becomes opaque and uses the selected system color scheme. 
+--help        | Displays this help message.
+
+### Color format
+The color parameter is interpreted as a three or four byte long number in hexadecimal format that 
+describes the four color channels ([alpha,] red, green and blue). These look like this: 
+0x80fe10a4 (the '0x' is optional). You often find colors in this format in the context of HTML and 
+web design, and there are many online tools to convert from familiar names to this format. These 
+tools might give you numbers starting with '#', in that case you can just remove the leading '#'. 
+You should be able to find online tools by searching for "color to hex" or something similar. 
+If the converter doesn't include alpha values (opacity), you can append them yourself at the start 
+of the number. Just convert a value between 0 and 255 to its hexadecimal value before you append it


### PR DESCRIPTION
Changed FindWindowA to FindWindowW, and changed to use explicit unicode text literals in the code. Implemented command line options to modify the appearance of the taskbar. These are "--blur", "--opaque", "--transparent" and "--tint COLOR", and are documented in the code. 