### PR TITLE
Added right-click support and removed definitions

### DIFF
--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,6 +1,3 @@
-// Those definitions are only in case you want to compile with cl.exe
-#define UNICODE
-#define _UNICODE
 #include <windows.h>
 #include <iostream>
 #include <string>

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -240,12 +240,12 @@ LRESULT CALLBACK TBPROCWND(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
 		PostQuitMessage(0);
 		break;
 	case WM_NOTIFY_TB:
-		if (lParam == WM_LBUTTONUP)
+		if (lParam == WM_LBUTTONUP || lParam == WM_RBUTTONUP)
 		{
 			POINT pt;
 			GetCursorPos(&pt);
 			SetForegroundWindow(hWnd);
-			UINT tray = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_RIGHTALIGN | TPM_NONOTIFY, pt.x, pt.y, 0, hWnd, NULL);
+			UINT tray = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_LEFTALIGN | TPM_NONOTIFY, pt.x, pt.y, 0, hWnd, NULL);
 			switch (tray)
 			{
 			case IDM_BLUR:


### PR DESCRIPTION
I just noticed you can build from the MSBUILD command line, and it that case you don't need the definitions.

~~I might open a PR in master's README for a quick and lazy build without opening VS via a command line.~~ Done