### PR TITLE
Updated RefreshHandles to update one vector of taskbars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ ModelManifest.xml
 
 # Visual Studio Code configuration
 .vscode/
+*.lnk
+README.md
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -244,5 +244,3 @@ ModelManifest.xml
 # Visual Studio Code configuration
 .vscode/
 *.lnk
-README.md
-README.md

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -41,7 +41,7 @@ const int ACCENT_ENABLE_GRADIENT = 1; // Makes the taskbar a solid color specifi
 const int ACCENT_ENABLE_TRANSPARENTGRADIENT = 2; // Makes the taskbar a tinted transparent overlay. nColor is the tint color, sending nothing results in it interpreted as 0x00000000 (totally transparent, blends in with desktop)
 const int ACCENT_ENABLE_BLURBEHIND = 3; // Makes the taskbar a tinted blurry overlay. nColor is same as above.
 unsigned int WM_TASKBARCREATED;
-std::vector<HWND> taskbars; // Create a vector for all second taskbars
+std::vector<HWND> taskbars; // Create a vector for all taskbars
 
 
 typedef BOOL(WINAPI*pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
@@ -347,7 +347,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int 
 				TranslateMessage(&msg);
 				DispatchMessage(&msg);
 			}
-			for(unsigned int i = 0; i > taskbars.size(); i++) {
+			for(int i = 0; i > 10; i++) {
 				SetWindowBlur(taskbars[i]);
 			}
 			Sleep(10);

--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -1,6 +1,7 @@
 #include <windows.h>
 #include <iostream>
 #include <string>
+#include <vector>
 
 //used for the tray things
 #include <shellapi.h>
@@ -40,7 +41,7 @@ const int ACCENT_ENABLE_GRADIENT = 1; // Makes the taskbar a solid color specifi
 const int ACCENT_ENABLE_TRANSPARENTGRADIENT = 2; // Makes the taskbar a tinted transparent overlay. nColor is the tint color, sending nothing results in it interpreted as 0x00000000 (totally transparent, blends in with desktop)
 const int ACCENT_ENABLE_BLURBEHIND = 3; // Makes the taskbar a tinted blurry overlay. nColor is same as above.
 unsigned int WM_TASKBARCREATED;
-
+std::vector<HWND> taskbars; // Create a vector for all second taskbars
 
 
 typedef BOOL(WINAPI*pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
@@ -221,8 +222,10 @@ void ParseOptions()
 
 void RefreshHandles()
 {
-	taskbar = FindWindowW(L"Shell_TrayWnd", NULL);
-	secondtaskbar = FindWindow(L"Shell_SecondaryTrayWnd", NULL); // we use this for the taskbars on other monitors.
+	taskbars.clear();
+	taskbars.push_back(FindWindowW(L"Shell_TrayWnd", NULL));
+	while (secondtaskbar = FindWindowEx(0, secondtaskbar, L"Shell_SecondaryTrayWnd", NULL))
+			taskbars.push_back(secondtaskbar); // We find all taskbars on second monitors and add them to a vector
 }
 
 #pragma endregion
@@ -340,14 +343,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int 
 		RefreshHandles();
 		WM_TASKBARCREATED = RegisterWindowMessage(L"TaskbarCreated");
 		while (run) {
-			SetWindowBlur(taskbar);
 			if (PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE)) {
 				TranslateMessage(&msg);
 				DispatchMessage(&msg);
 			}
-			while (secondtaskbar = FindWindowEx(0, secondtaskbar, L"Shell_SecondaryTrayWnd", L""))
-			{
-				SetWindowBlur(secondtaskbar);
+			for(unsigned int i = 0; i > taskbars.size(); i++) {
+				SetWindowBlur(taskbars[i]);
 			}
 			Sleep(10);
 		}


### PR DESCRIPTION
Changed RefreshHandles to update one vector of taskbars, which includes all secondary taskbars. Then the script loops through all in that vector and runs SetWindowBlur on it; this means that if you have secondary taskbars the script isn't searching for all of them. Hopefully this reduces CPU usage for those with many secondary monitors.